### PR TITLE
Fix asset paths for GitHub Pages

### DIFF
--- a/src/components/Planet.jsx
+++ b/src/components/Planet.jsx
@@ -11,7 +11,7 @@ export function Planet(props) {
   const shapeContainer = useRef(null);
   const shperesContainer = useRef(null);
   const ringContainer = useRef(null);
-  const { nodes, materials } = useGLTF("/models/Planet.glb");
+  const { nodes, materials } = useGLTF("/portfolio/models/Planet.glb");
 
   useGSAP(() => {
     const tl = gsap.timeline();
@@ -77,4 +77,4 @@ export function Planet(props) {
   );
 }
 
-useGLTF.preload("/models/Planet.glb");
+useGLTF.preload("/portfolio/models/Planet.glb");

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -84,8 +84,8 @@ export const projects = [
     description:
       "An online store specializing in phone accessories including cases, chargers, cables, and power banks with MagSafe compatibility.",
     href: "",
-    image: "/assets/projects/mobile-accessories-store.jpg",
-    bgImage: "/assets/backgrounds/blanket.jpg",
+    image: "/portfolio/assets/projects/mobile-accessories-store.jpg",
+    bgImage: "/portfolio/assets/backgrounds/blanket.jpg",
     frameworks: [
       { id: 1, name: "React" },
       { id: 2, name: "Next.js" },
@@ -100,8 +100,8 @@ export const projects = [
     description:
       "An online store specializing in rare and decorative plants with a clean, user-friendly interface.",
     href: "",
-    image: "/assets/projects/plant-shop.jpg",
-    bgImage: "/assets/backgrounds/curtains.jpg",
+    image: "/portfolio/assets/projects/plant-shop.jpg",
+    bgImage: "/portfolio/assets/backgrounds/curtains.jpg",
     frameworks: [
       { id: 1, name: "React" },
       { id: 2, name: "Next.js" },
@@ -115,8 +115,8 @@ export const projects = [
     description:
       "An e-commerce platform for Apple products and accessories with deals and category filtering.",
     href: "",
-    image: "/assets/projects/apple-tech-store.jpg",
-    bgImage: "/assets/backgrounds/map.jpg",
+    image: "/portfolio/assets/projects/apple-tech-store.jpg",
+    bgImage: "/portfolio/assets/backgrounds/map.jpg",
     frameworks: [
       { id: 1, name: "Blazor" },
       { id: 2, name: "ASP.NET Core" },
@@ -130,8 +130,8 @@ export const projects = [
     description:
       "A multi-category online shop featuring electronics, home appliances, and gaming gear with special offers.",
     href: "",
-    image: "/assets/projects/electronics-store.jpg",
-    bgImage: "/assets/backgrounds/poster.jpg",
+    image: "/portfolio/assets/projects/electronics-store.jpg",
+    bgImage: "/portfolio/assets/backgrounds/poster.jpg",
     frameworks: [
       { id: 1, name: "Vue.js" },
       { id: 2, name: "Laravel" },
@@ -145,8 +145,8 @@ export const projects = [
     description:
       "A curated collection of designer home decor items, including furniture and artisan vases.",
     href: "",
-    image: "/assets/projects/home-decor-store.jpg",
-    bgImage: "/assets/backgrounds/table.jpg",
+    image: "/portfolio/assets/projects/home-decor-store.jpg",
+    bgImage: "/portfolio/assets/backgrounds/table.jpg",
     frameworks: [
       { id: 1, name: "Angular" },
       { id: 2, name: "Firebase" },
@@ -160,8 +160,8 @@ export const projects = [
     description:
       "A gaming platform featuring discounted titles, top sellers, and genre-based browsing.",
     href: "",
-    image: "/assets/projects/game-store.jpg",
-    bgImage: "/assets/backgrounds/curtains.jpg",
+    image: "/portfolio/assets/projects/game-store.jpg",
+    bgImage: "/portfolio/assets/backgrounds/curtains.jpg",
     frameworks: [
       { id: 1, name: "Svelte" },
       { id: 2, name: "Node.js" },

--- a/src/index.css
+++ b/src/index.css
@@ -3,8 +3,8 @@
 /* Amiamie Regular */
 @font-face {
   font-family: "Amiamie";
-  src: url("/fonts/otf/Amiamie-Regular.otf") format("opentype"),
-    url("/fonts/ttf/Amiamie-Regular.ttf") format("truetype");
+  src: url("/portfolio/fonts/otf/Amiamie-Regular.otf") format("opentype"),
+    url("/portfolio/fonts/ttf/Amiamie-Regular.ttf") format("truetype");
   font-weight: 400;
   font-style: normal;
   font-display: swap;
@@ -13,8 +13,8 @@
 /* Amiamie Regular Italic */
 @font-face {
   font-family: "Amiamie";
-  src: url("/fonts/otf/Amiamie-Italic.otf") format("opentype"),
-    url("/fonts/ttf/Amiamie-Italic.ttf") format("truetype");
+  src: url("/portfolio/fonts/otf/Amiamie-Italic.otf") format("opentype"),
+    url("/portfolio/fonts/ttf/Amiamie-Italic.ttf") format("truetype");
   font-weight: 400;
   font-style: italic;
   font-display: swap;
@@ -23,8 +23,8 @@
 /* Amiamie Light */
 @font-face {
   font-family: "Amiamie";
-  src: url("/fonts/otf/Amiamie-Light.otf") format("opentype"),
-    url("/fonts/ttf/Amiamie-Light.ttf") format("truetype");
+  src: url("/portfolio/fonts/otf/Amiamie-Light.otf") format("opentype"),
+    url("/portfolio/fonts/ttf/Amiamie-Light.ttf") format("truetype");
   font-weight: 300;
   font-style: normal;
   font-display: swap;
@@ -33,8 +33,8 @@
 /* Amiamie Light Italic */
 @font-face {
   font-family: "Amiamie";
-  src: url("/fonts/otf/Amiamie-LightItalic.otf") format("opentype"),
-    url("/fonts/ttf/Amiamie-LightItalic.ttf") format("truetype");
+  src: url("/portfolio/fonts/otf/Amiamie-LightItalic.otf") format("opentype"),
+    url("/portfolio/fonts/ttf/Amiamie-LightItalic.ttf") format("truetype");
   font-weight: 300;
   font-style: italic;
   font-display: swap;
@@ -43,8 +43,8 @@
 /* Amiamie Black */
 @font-face {
   font-family: "Amiamie";
-  src: url("/fonts/otf/Amiamie-Black.otf") format("opentype"),
-    url("/fonts/ttf/Amiamie-Black.ttf") format("truetype");
+  src: url("/portfolio/fonts/otf/Amiamie-Black.otf") format("opentype"),
+    url("/portfolio/fonts/ttf/Amiamie-Black.ttf") format("truetype");
   font-weight: 900;
   font-style: normal;
   font-display: swap;
@@ -53,8 +53,8 @@
 /* Amiamie Black Italic */
 @font-face {
   font-family: "Amiamie";
-  src: url("/fonts/otf/Amiamie-BlackItalic.otf") format("opentype"),
-    url("/fonts/ttf/Amiamie-BlackItalic.ttf") format("truetype");
+  src: url("/portfolio/fonts/otf/Amiamie-BlackItalic.otf") format("opentype"),
+    url("/portfolio/fonts/ttf/Amiamie-BlackItalic.ttf") format("truetype");
   font-weight: 900;
   font-style: italic;
   font-display: swap;
@@ -63,8 +63,8 @@
 /* Amiamie-Round Variants (if needed separately) */
 @font-face {
   font-family: "Amiamie-Round";
-  src: url("/fonts/otf/Amiamie-RegularRound.otf") format("opentype"),
-    url("/fonts/ttf/Amiamie-RegularRound.ttf") format("truetype");
+  src: url("/portfolio/fonts/otf/Amiamie-RegularRound.otf") format("opentype"),
+    url("/portfolio/fonts/ttf/Amiamie-RegularRound.ttf") format("truetype");
   font-weight: 400;
   font-style: normal;
   font-display: swap;
@@ -72,8 +72,8 @@
 
 @font-face {
   font-family: "Amiamie-Round";
-  src: url("/fonts/otf/Amiamie-BlackRound.otf") format("opentype"),
-    url("/fonts/ttf/Amiamie-BlackRound.ttf") format("truetype");
+  src: url("/portfolio/fonts/otf/Amiamie-BlackRound.otf") format("opentype"),
+    url("/portfolio/fonts/ttf/Amiamie-BlackRound.ttf") format("truetype");
   font-weight: 900;
   font-style: normal;
   font-display: swap;
@@ -81,8 +81,8 @@
 
 @font-face {
   font-family: "Amiamie-Round";
-  src: url("/fonts/otf/Amiamie-BlackItalicRound.otf") format("opentype"),
-    url("/fonts/ttf/Amiamie-BlackItalicRound.ttf") format("truetype");
+  src: url("/portfolio/fonts/otf/Amiamie-BlackItalicRound.otf") format("opentype"),
+    url("/portfolio/fonts/ttf/Amiamie-BlackItalicRound.ttf") format("truetype");
   font-weight: 900;
   font-style: italic;
   font-display: swap;

--- a/src/sections/About.jsx
+++ b/src/sections/About.jsx
@@ -50,7 +50,7 @@ const About = () => {
       <div className="flex flex-col items-center justify-between gap-16 px-10 pb-16 text-xl font-light tracking-wide lg:flex-row md:text-2xl lg:text-3xl text-white/60">
         <img
           ref={imgRef}
-          src="images/man.jpg"
+          src="/portfolio/images/man.jpg"
           alt="man"
           className="w-md rounded-3xl"
         />


### PR DESCRIPTION
## Summary
- update font URLs in CSS to use `/portfolio` base path
- update About section image path for GitHub Pages
- adjust 3D model path for useGLTF
- set project image paths with `/portfolio` base path

## Testing
- `npm run build` *(fails: vite not found)*
- `npx serve dist` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686c596a7214832d84e151378fe9f736